### PR TITLE
Use `replaceAll`, fixes #4

### DIFF
--- a/11tyAutoCacheBuster.js
+++ b/11tyAutoCacheBuster.js
@@ -103,7 +103,7 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
                             assetHash = assetHash.substring(0, hashTruncate);
                         }
 
-                        outputData = outputData.replaceAll(`${assetPath}?v=${assetHash}`);
+                        outputData = outputData.replaceAll(assetPath, `${assetPath}?v=${assetHash}`);
                         outputChanged = true;
                         
                     } else {

--- a/11tyAutoCacheBuster.js
+++ b/11tyAutoCacheBuster.js
@@ -103,7 +103,7 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
                             assetHash = assetHash.substring(0, hashTruncate);
                         }
 
-                        outputData = outputData.replace(assetPath, assetPath + "?v=" + assetHash);
+                        outputData = outputData.replaceAll(`${assetPath}?v=${assetHash}`);
                         outputChanged = true;
                         
                     } else {


### PR DESCRIPTION
Fixes #4.

Note that I haven't tested this as well as I would like -- please test it before merging and releasing!

Also replaced string concatenation with a template literal because IMO it's easier to read.