### PR TITLE
Adds support for custom glob options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ module.exports = function (eleventyConfig) {
         hashTruncate: 0,  // Desired substring length of the hash. Set to 0 or lower to disable truncating
         runAsync: false,  // Whether to run asynchronously. Default is true
         globstring: "subdir/**/*",  // What glob string is used to locate assets.
+        globOptions: {nodir: true, ignore: ['node_modules/**', 'tmp/**']} // exclude multiple files or directories. (NOTE: `nodir` will remain be true).  Reference: https://github.com/isaacs/node-glob#readme
         extensions: ["css"],  // What file extensions are accepted when locating assets.
         hashAlgorithm: "sha1",  // What hash method to pass to the hash function. See Node.js' crypto.createHash documentation.
         hashFunction: function (content) { return "example" }  // What function to run to calculate hashes. Overrides hashAlgorithm.


### PR DESCRIPTION
For my use case, there are specific files I want ignored although the file extension is included in the array of file types.

E.g. 
```
options = {
    ....
    extensions: [ "css", "js", "png", "jpg", "json", "xml"], 
    globOptions: {ignore: ["/path/to/special.xml", "/path/to/some-other-file.json"]},
    ....
}
```

Logic is added where `nodir` remains set to `true` and cannot be overridden.
I imagine others may find this useful.
