### PR TITLE
Adds condition to bypass explicitly ignored files when replacing assets

### DIFF
--- a/11tyAutoCacheBuster.js
+++ b/11tyAutoCacheBuster.js
@@ -144,7 +144,7 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
 
             logRegular(`[ACB] Replacing in output...`);
             results.forEach(({inputPath, outputPath, url, content}) => {
-                if (!globOptions.ignore.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
+                if (!globOptions.ignore?.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
                     fs.readFile(outputPath, encoding="UTF-8", (err, pageData) => { 
                         if (err) {
                             logRed(err);
@@ -163,7 +163,7 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
 
             logRegular(`[ACB] Replacing in output...`);
             results.forEach(({inputPath, outputPath, url, content}) => {
-                if (!globOptions.ignore.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
+                if (!globOptions.ignore?.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
                     const pageData = fs.readFileSync(outputPath, encoding="UTF-8"); 
                     // Save the output data
                     replaceAssetsInFile(pageData, outputPath, assetPathsAndHashes, writeSync);

--- a/11tyAutoCacheBuster.js
+++ b/11tyAutoCacheBuster.js
@@ -144,14 +144,16 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
 
             logRegular(`[ACB] Replacing in output...`);
             results.forEach(({inputPath, outputPath, url, content}) => {
-                fs.readFile(outputPath, encoding="UTF-8", (err, pageData) => { 
-                    if (err) {
-                        logRed(err);
-                        throw err;
-                    }
-                    // Save the output data
-                    replaceAssetsInFile(pageData, outputPath, assetPathsAndHashes, writeAsync);
-                });
+                if (!globOptions.ignore.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
+                    fs.readFile(outputPath, encoding="UTF-8", (err, pageData) => { 
+                        if (err) {
+                            logRed(err);
+                            throw err;
+                        }
+                        // Save the output data
+                        replaceAssetsInFile(pageData, outputPath, assetPathsAndHashes, writeAsync);
+                    });
+                }
             });
         });
     } else {
@@ -161,9 +163,11 @@ module.exports = function(eleventyConfig, options=defaultOptions) {
 
             logRegular(`[ACB] Replacing in output...`);
             results.forEach(({inputPath, outputPath, url, content}) => {
-                const pageData = fs.readFileSync(outputPath, encoding="UTF-8"); 
-                // Save the output data
-                replaceAssetsInFile(pageData, outputPath, assetPathsAndHashes, writeSync);
+                if (!globOptions.ignore.includes(outputPath)) { // -- Do not attempt to read explicitly ignored files as they may no longer exist!
+                    const pageData = fs.readFileSync(outputPath, encoding="UTF-8"); 
+                    // Save the output data
+                    replaceAssetsInFile(pageData, outputPath, assetPathsAndHashes, writeSync);
+                }
             });
         });
     }


### PR DESCRIPTION
While the previous release adds the ability to explicitly ignore files and directories when using glob, this PR adds logic to prevent unnecessary reading of those explicitly ignored files when attempting to replace assets.  

During the build process, it is possible that ignored files may no longer exist.  Attempting to read these files causes uncaught errors to be thrown, which in turn results in failed deployments.

Adding the logic in this PR maintains asset replacement logic while preventing unnecessary build failures.